### PR TITLE
feat(ui):  Custom codeblock creation UI component modal

### DIFF
--- a/client/components/playground/floatingWindow/FloatingSidebar.tsx
+++ b/client/components/playground/floatingWindow/FloatingSidebar.tsx
@@ -140,12 +140,12 @@ function toggleReducer(state: ToggleState, action:ToggleAction ): ToggleState {
 interface CustomBlockModalProps {
   isOpen: boolean;
   onClose: () => void;
-  onSubmit: (values: { blockName: string; solidityCode: string }) => void;
+  onSubmit: (values: { blockName: string; cairoCode: string }) => void;
 }
 
 const formSchema = z.object({
   blockName: z.string().min(1, "Block name is required"),
-  solidityCode: z.string().min(1, "Solidity code is required"),
+  cairoCode: z.string().min(1, "Cairo code is required"),
 });
 
 function CustomBlockModal({ isOpen, onClose, onSubmit }: CustomBlockModalProps) {
@@ -153,7 +153,7 @@ function CustomBlockModal({ isOpen, onClose, onSubmit }: CustomBlockModalProps) 
     resolver: zodResolver(formSchema),
     defaultValues: {
       blockName: "",
-      solidityCode: "",
+      cairoCode: "",
     },
   });
 
@@ -175,14 +175,14 @@ function CustomBlockModal({ isOpen, onClose, onSubmit }: CustomBlockModalProps) 
             )}
           </div>
           <div className="mb-4">
-            <label className="block text-sm font-medium text-gray-700">Solidity Code</label>
+            <label className="block text-sm font-medium text-gray-700">Cairo Code</label>
             <textarea
-              {...form.register("solidityCode")}
+              {...form.register("cairoCode")}
               className="mt-1 block w-full px-3 py-2 border border-gray-300 text-white rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
               rows={4}
             />
-            {form.formState.errors.solidityCode && (
-              <p className="text-red-500 text-sm">{form.formState.errors.solidityCode.message}</p>
+            {form.formState.errors.cairoCode && (
+              <p className="text-red-500 text-sm">{form.formState.errors.cairoCode.message}</p>
             )}
           </div>
           <div className="flex justify-end">
@@ -226,14 +226,14 @@ export default function FloatingSidebar({ addBlock }: FloatingSidebarProps) {
 
   const formSchema = z.object({
     blockName: z.string().min(1, "Block name is required"),
-    solidityCode: z.string().min(1, "Solidity code is required"),
+    cairoCode: z.string().min(1, "Cairo code is required"),
   })
 
   const form = useForm({
     resolver: zodResolver(formSchema),
     defaultValues: {
       blockName: "",
-      solidityCode: "",
+      cairoCode: "",
     },
   })
   return (
@@ -502,7 +502,7 @@ export default function FloatingSidebar({ addBlock }: FloatingSidebarProps) {
       borderColor: 'border-[#6C6C6C]',
       hoverBorderColor: 'hover:border-[#9C9C9C]',
       icon: Code,
-      code: values.solidityCode,
+      code: values.cairoCode,
     }
   
     addBlock(newCustomBlock)

--- a/client/components/playground/floatingWindow/FloatingSidebar.tsx
+++ b/client/components/playground/floatingWindow/FloatingSidebar.tsx
@@ -137,6 +137,74 @@ function toggleReducer(state: ToggleState, action:ToggleAction ): ToggleState {
   }
 }
 
+interface CustomBlockModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSubmit: (values: { blockName: string; solidityCode: string }) => void;
+}
+
+const formSchema = z.object({
+  blockName: z.string().min(1, "Block name is required"),
+  solidityCode: z.string().min(1, "Solidity code is required"),
+});
+
+function CustomBlockModal({ isOpen, onClose, onSubmit }: CustomBlockModalProps) {
+  const form = useForm({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      blockName: "",
+      solidityCode: "",
+    },
+  });
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex justify-center items-center">
+      <div className="bg-white p-6 rounded-lg w-96">
+        <h2 className="text-lg font-bold mb-4">Create Custom Block</h2>
+        <form onSubmit={form.handleSubmit(onSubmit)}>
+          <div className="mb-4">
+            <label className="block text-sm font-medium text-gray-700">Block Name</label>
+            <input
+              {...form.register("blockName")}
+              className="mt-1 block w-full px-3 py-2 border border-gray-300 text-white rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
+            />
+            {form.formState.errors.blockName && (
+              <p className="text-red-500 text-sm">{form.formState.errors.blockName.message}</p>
+            )}
+          </div>
+          <div className="mb-4">
+            <label className="block text-sm font-medium text-gray-700">Solidity Code</label>
+            <textarea
+              {...form.register("solidityCode")}
+              className="mt-1 block w-full px-3 py-2 border border-gray-300 text-white rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
+              rows={4}
+            />
+            {form.formState.errors.solidityCode && (
+              <p className="text-red-500 text-sm">{form.formState.errors.solidityCode.message}</p>
+            )}
+          </div>
+          <div className="flex justify-end">
+            <button
+              type="button"
+              onClick={onClose}
+              className="mr-2 px-4 py-2 bg-gray-300 rounded-md hover:bg-gray-400"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              className="px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700"
+            >
+              Create
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
 
 export default function FloatingSidebar({ addBlock }: FloatingSidebarProps) {
   const [{triggerActionToggle,
@@ -400,12 +468,12 @@ export default function FloatingSidebar({ addBlock }: FloatingSidebarProps) {
               </div>}
             </div>
             
-            <div className="px-3 py-2">
-              <div className="flex gap-3">
-                <span><MenuIcon/></span>
-                <div className="text-black">Custom</div>
-              </div>      
+            <div className="px-3 py-2 cursor-pointer" onClick={() => setIsCustomModalOpen(true)}>
+            <div className="flex gap-3">
+              <span><MenuIcon /></span>
+              <div className="text-black">Custom</div>
             </div>
+          </div>
           </div>
         </div>
 
@@ -417,6 +485,12 @@ export default function FloatingSidebar({ addBlock }: FloatingSidebarProps) {
           </button>
         </div>
       </div>
+
+      <CustomBlockModal
+        isOpen={isCustomModalOpen}
+        onClose={() => setIsCustomModalOpen(false)}
+        onSubmit={onSubmitCustomBlock}
+      />
     </div>
   );
 


### PR DESCRIPTION
## 🚀 Pull Request Description
This PR introduces a custom codeblock creation UI component. When the "Custom" option in the FloatingSidebar is clicked, a modal pops up allowing users to input the name and content of a custom node. The modal uses `react-hook-form` for form management and validation, and the submitted data is used to create a new custom block.

[Provide a clear and concise description of the changes in this pull request.]

## 🔗 Linked Issues
Fixes #124 


## 🧪 Testing Instructions

1. **Open the FloatingSidebar**:
   - Navigate to the FloatingSidebar component in the application.
   
2. **Click the "Custom" Option**:
   - Click on the "Custom" option in the Token Action section.
   - Verify that a modal pops up with fields for "Block Name" and "Cairo Code".

3. **Fill Out the Form**:
   - Enter a block name (e.g., "My Custom Block").
   - Enter some Cairo code (e.g., `function myFunction() public {}`).
   - Click the "Create" button.

4. **Verify the Block is Added**:
   - Ensure the new custom block is added to the list of blocks.
   - Verify that the modal closes after submission.

5. **Validation Testing**:
   - Leave the "Block Name" or "Cairo Code" fields empty and try to submit.
   - Verify that validation errors are displayed.

6. **Cancel the Modal**:
   - Click the "Cancel" button in the modal.
   - Verify that the modal closes without creating a block.


## 📸 Screenshots
[Screencast from 2025-02-22 12-07-45.webm](https://github.com/user-attachments/assets/aca39bd3-b3e8-4366-b492-e5e967b32f84)


## ✅ PR Checklist
---

- [x] I have tested these changes locally
- [x] Relevant documentation is updated
- [x] My code follows the repository's coding guidelines
- [x] I have added/updated tests that prove my fix/feature
- [x] No breaking changes introduced
- [x] Code is well-commented and readable