### PR TITLE
installing rust before Scarb with a safe version

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -21,6 +21,12 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y build-essential libssl-dev pkg-config
 
+      - name: Install Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: 1.78.0
+          override: true
+
       - name: Install Scarb
         run: curl --proto '=https' --tlsv1.2 -sSf https://docs.swmansion.com/scarb/install.sh | sh -s -- -v 2.9.4
 
@@ -35,9 +41,6 @@ jobs:
             ~/.cargo/git
             client/app/devx/contracts/utility-contracts/fee-deduction/target/
           key: ${{ runner.os }}-rust-${{ hashFiles('**/Cargo.lock') }}
-
-      - name: Install Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Install wasm32 target
         run: rustup target add wasm32-unknown-unknown


### PR DESCRIPTION
## 🚀 Pull Request Description

## Description

This PR updates the CI/CD pipeline configuration (.github/workflows/ci-cd.yml)
The Rust toolchain should be installed before Scarb, otherwise Scarb can’t compile its plugins.

## 🔗 Linked Issues

working on issue #438 , review needed


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring, dependency updates, etc.)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [ ] Tested locally with full stack setup

## ✅ PR Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have tested these changes locally
- [ ] Relevant documentation is updated
- [ ] My code follows the repository's coding guidelines
- [ ] I have added/updated tests that prove my fix/feature
- [ ] No breaking changes introduced
- [ ] Code is well-commented and readable
