### PR TITLE
fix: run docker and deploy jobs on PRs as well as main

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -122,7 +122,7 @@ jobs:
     permissions:
       contents: read
       packages: write
-    if: github.ref == 'refs/heads/main'
+  if: github.ref == 'refs/heads/main' || github.event_name == 'pull_request'
 
     steps:
       - uses: actions/checkout@v4
@@ -148,7 +148,7 @@ jobs:
   deploy:
     needs: [check-contracts, nextjs-build-and-test, docker-build-and-push]
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
+  if: github.ref == 'refs/heads/main' || github.event_name == 'pull_request'
     defaults:
       run:
         working-directory: ./client


### PR DESCRIPTION
### Summary

This PR updates the GitHub Actions workflow so that the `docker-build-and-push` and `deploy` jobs run on both pull requests and direct pushes to the `main` branch. Previously, these jobs were skipped on PRs due to a restrictive `if` condition.

---

### Linked Issues

Closes #410 

---

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

---

### How Has This Been Tested?

- [x] Opened a pull request and confirmed that all CI/CD jobs run as expected.

---

### Checklist

- [x] Code follows project style guidelines
- [x] No new warnings or errors
- [x] CI/CD checks now run on PRs and main